### PR TITLE
Issue 2

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -94,6 +94,15 @@ if(EMSCRIPTEN AND PMP_BUILD_VIS)
       "--shell-file ${CMAKE_CURRENT_SOURCE_DIR}/data/shell.html --preload-file ${PROJECT_SOURCE_DIR}/external/pmp-data/off/fandisk.off@input.off"
   )
 
+  add_executable(merge merge.cpp data/shell.html)
+  target_link_libraries(merge pmp_vis)
+  set_target_properties(
+    merge
+    PROPERTIES
+      LINK_FLAGS
+      "--shell-file ${CMAKE_CURRENT_SOURCE_DIR}/data/shell.html --preload-file ${PROJECT_SOURCE_DIR}/external/pmp-data/off/fandisk.off@input.off"
+  )
+
   add_executable(parameterization parameterization.cpp data/shell.html)
   target_link_libraries(parameterization pmp_vis)
   set_target_properties(
@@ -134,6 +143,9 @@ else()
 
     add_executable(decimation decimation.cpp)
     target_link_libraries(decimation pmp_vis)
+
+    add_executable(merge merge.cpp)
+    target_link_libraries(merge pmp_vis)
 
     add_executable(remeshing remeshing.cpp)
     target_link_libraries(remeshing pmp_vis)

--- a/examples/merge.cpp
+++ b/examples/merge.cpp
@@ -1,0 +1,169 @@
+// Copyright 2011-2019 the Polygon Mesh Processing Library developers.
+// Distributed under a MIT-style license, see LICENSE.txt for details.
+
+#include <pmp/visualization/MeshViewer.h>
+#include <pmp/algorithms/Decimation.h>
+#include <pmp/algorithms/Merge.h>
+#include <pmp/algorithms/Normals.h>
+#include <imgui.h>
+
+using namespace pmp;
+
+class Viewer : public MeshViewer
+{
+public:
+    Viewer(const char* title, int width, int height);
+
+    void create_mesh() { 
+        create_open_cube();
+    }
+
+    void create_open_cube() {
+        auto v0 = mesh_.add_vertex(pmp::Point(-0.5, -0.5, -0.5));
+        auto v1 = mesh_.add_vertex(pmp::Point(0.5, -0.5, -0.5));
+        auto v2 = mesh_.add_vertex(pmp::Point(0.5, 0.5, -0.5));
+        auto v3 = mesh_.add_vertex(pmp::Point(-0.5, 0.5, -0.5));
+        auto v4 = mesh_.add_vertex(pmp::Point(-0.5, 0.5, 0.5));
+        auto v5 = mesh_.add_vertex(pmp::Point(0.5, 0.5, 0.5));
+        auto v6 = mesh_.add_vertex(pmp::Point(0.5, -0.5, 0.5));
+        auto v7 = mesh_.add_vertex(pmp::Point(-0.5, -0.5, 0.5));
+
+        mesh_.add_triangle(v0, v2, v1);
+        mesh_.add_triangle(v0, v3, v2);
+        mesh_.add_triangle(v2, v3, v4);
+        mesh_.add_triangle(v2, v4, v5);
+        mesh_.add_triangle(v1, v2, v5);
+        mesh_.add_triangle(v1, v5, v6);
+        mesh_.add_triangle(v0, v7, v4);
+        mesh_.add_triangle(v0, v4, v3);
+        mesh_.add_triangle(v5, v4, v7);
+        mesh_.add_triangle(v5, v7, v6);
+        mesh_.add_triangle(v0, v6, v7);
+        mesh_.add_triangle(v0, v1, v6);
+
+        remove_incident_faces();
+
+        prepare_mesh(mesh_);
+
+        update_mesh();
+    }
+
+    void prepare_mesh(SurfaceMesh& b)
+    {
+        auto a = SurfaceMesh(b);
+        b.clear();
+        auto a_p = a.get_vertex_property<pmp::Point>("v:point");
+        for (auto f : a.faces())
+        {
+            std::vector<Vertex> b_vertices;
+            for (auto v : a.vertices(f))
+            {
+                b_vertices.push_back(b.add_vertex(a_p[v]));
+            }
+            b.add_face(b_vertices);
+        }
+        Normals::compute_vertex_normals(b);
+    }
+
+    void remove_incident_faces()
+    {
+        auto v = *mesh_.vertices_begin();
+        std::vector<pmp::Face> faces;
+        for (auto f : mesh_.faces(v))
+        {
+            faces.push_back(f);
+        }
+        mesh_.delete_face(faces[0]);
+        mesh_.delete_face(faces[1]);
+    }
+
+    void remove_nonincident_faces()
+    {
+        auto v = *mesh_.vertices_begin();
+        std::vector<pmp::Face> faces;
+        for (auto f : mesh_.faces(v))
+        {
+            faces.push_back(f);
+        }
+        mesh_.delete_face(faces[0]);
+        mesh_.delete_face(faces[3]);
+    }
+
+protected:
+    void process_imgui() override;
+};
+
+Viewer::Viewer(const char* title, int width, int height)
+    : MeshViewer(title, width, height)
+{
+    set_draw_mode("Hidden Line");
+    crease_angle_ = 0.0;
+}
+
+void Viewer::process_imgui()
+{
+    MeshViewer::process_imgui();
+
+    ImGui::Spacing();
+    ImGui::Spacing();
+
+    if (ImGui::Button("Merge"))
+    {
+        Merge m(mesh_);
+        m.merge();
+        mesh_.garbage_collection();
+        update_mesh();
+    }
+
+    if (ImGui::CollapsingHeader("Decimation", ImGuiTreeNodeFlags_DefaultOpen))
+    {
+        static int target_percentage = 10;
+        ImGui::PushItemWidth(100);
+        ImGui::SliderInt("Percentage", &target_percentage, 1, 99);
+        ImGui::PopItemWidth();
+
+        static int normal_deviation = 30;
+        ImGui::PushItemWidth(100);
+        ImGui::SliderInt("Normal Deviation", &normal_deviation, 1, 180);
+        ImGui::PopItemWidth();
+
+        static int aspect_ratio = 0;
+        ImGui::PushItemWidth(100);
+        ImGui::SliderInt("Aspect Ratio", &aspect_ratio, 0, 1000);
+        ImGui::PopItemWidth();
+
+        if (ImGui::Button("Decimate"))
+        {
+            try
+            {
+                Decimation decimater(mesh_);
+                decimater.initialize(aspect_ratio, 0.0, 0.0, normal_deviation,
+                                     0.0);
+                decimater.decimate(mesh_.n_vertices() * 0.01 *
+                                   target_percentage);
+            }
+            catch (const InvalidInputException& e)
+            {
+                std::cerr << e.what() << std::endl;
+                return;
+            }
+            update_mesh();
+        }
+    }
+}
+
+int main(int argc, char** argv)
+{
+#ifndef __EMSCRIPTEN__
+    Viewer window("Merge and Decimate", 800, 600);
+    if (argc == 2)
+        window.load_mesh(argv[1]);
+    else
+        window.create_open_cube();
+    return window.run();
+#else
+    Viewer window("Decimation", 800, 600);
+    window.load_mesh(argc == 2 ? argv[1] : "input.off");
+    return window.run();
+#endif
+}

--- a/src/pmp/SurfaceMesh.h
+++ b/src/pmp/SurfaceMesh.h
@@ -1869,6 +1869,10 @@ public:
         return Face(static_cast<IndexType>(faces_size()) - 1);
     }
 
+    // Merges boundary h1 into non-boundary h2, connecting the incident faces
+    // and removing the boundary.
+    void combine_edges(Halfedge h1, Halfedge h2);
+
     //!@}
 
 private:

--- a/src/pmp/algorithms/Merge.cpp
+++ b/src/pmp/algorithms/Merge.cpp
@@ -1,0 +1,202 @@
+#pragma optimize("", off)
+
+#include "pmp/algorithms/Merge.h"
+#include "pmp/algorithms/Normals.h"
+
+/**
+ * The Compression Algorithm combines vertices co-located in space.
+ * Only vertices with normals within the specified range are combined, in order
+ * to preserve corners. 
+ * This implementation does not consider texture coordinates.
+ * 
+ * The algorithm works by building a spatial hash of vertex points, and then
+ * comparing the distance of vertices within each cell. Vertices below the
+ * distance_threshold are combined by redirecting all references to one vertex to the
+ * other, then deleting the original. Afterwards, duplicate edges are removed 
+ * connecting incident faces.
+ * 
+ * In this implementation, tolerance is suggestive only: vertices might not be 
+ * merged if they sit on the edge of cells. To support his, the cell key should 
+ * be made a union so that border cells can be easily queried/the vertex can be 
+ * added to bordering cells when the map is constructed.
+ */
+
+using namespace pmp;
+
+Merge::Merge(SurfaceMesh& mesh) : mesh(mesh) 
+{
+    distance_threshold = 0.0;
+    angle_threshold_radians = 30.0 * (M_PI / 180.0);
+
+    // The algorithm expects per-vertex normals
+    if (!mesh.has_vertex_property("v:normal"))
+    {
+        Normals::compute_vertex_normals(mesh);
+    }
+}
+
+void Merge::merge(float angle_degrees, float tolerance) 
+{
+    this->angle_threshold_radians = angle_degrees * (M_PI / 180.0);
+    this->distance_threshold = tolerance;
+    build_map();
+    merge_vertices();
+    merge_edges();
+}
+
+void Merge::build_map()
+{
+    map.clear();
+    bounds = BoundingBox();
+
+    // Use a spatial hash to find co-located vertices
+
+    auto positions = mesh.get_vertex_property<pmp::Point>("v:point");
+    for (auto& p : positions.vector())
+    {
+        bounds += p;
+    }
+
+    // Each cell key is a 64 bit integer, with 21 bits for each x, y &
+    // z component, concatenated together. For simplicity, cells are
+    // uniform cubes.
+
+    auto bounds_size = bounds.max() - bounds.min();
+    auto max_dimension = std::max(
+        std::max(bounds_size(0, 0), bounds_size(1, 0)), bounds_size(2, 0));
+    auto min_cell_size = max_dimension / (float)0x1FFFFF;
+
+    auto cell_size = std::max(distance_threshold, min_cell_size);
+
+    for (auto v : mesh.vertices())
+    {
+        auto position = positions[v] - bounds.min();
+
+        uint64_t xi = position[0] / cell_size;
+        uint64_t yi = position[1] / cell_size;
+        uint64_t zi = position[2] / cell_size;
+
+        assert((xi & 0x1FFFFF) == xi);
+        assert((yi & 0x1FFFFF) == yi);
+        assert((zi & 0x1FFFFF) == zi);
+
+        uint64_t cell = (xi << 42) | (yi << 21) | zi;
+
+        map[cell].push_back(v);
+    }
+}
+
+void Merge::merge_vertices()
+{
+    std::vector<std::pair<Vertex, Vertex>> merge;
+
+    auto positions = mesh.get_vertex_property<pmp::Point>("v:point");
+    auto normals = mesh.get_vertex_property<pmp::Point>("v:normal");
+
+    // Using the map compare potential vertex pairs
+
+    for (auto pair : map)
+    {
+        auto vertices = pair.second;
+        for (size_t i = 0; i < vertices.size(); i++)
+        {
+            for (size_t j = i + 1; j < vertices.size(); j++)
+            {
+                auto v0 = vertices[i];
+                auto v1 = vertices[j];
+
+                if (distance(positions[v0], positions[v1]) > distance_threshold)
+                {
+                    continue;
+                }
+
+                if(acos(dot(normals[v0], normals[v1])) > angle_threshold_radians)
+                {
+                    continue;
+                }
+
+                merge.push_back({v0, v1});
+            }
+        }
+    }
+
+    for (auto pair : merge)
+    {
+        if (mesh.is_deleted(pair.first))
+        {
+            continue;
+        }
+        if (mesh.is_deleted(pair.second))
+        {
+            continue;
+        }
+        merge_vertices(pair.first, pair.second);
+    }
+}
+
+// Collapses /p v1 into /p v0 and deletes /p v1. Collapsing means
+// all references to v1 are replaced with v0.
+void Merge::merge_vertices(Vertex v0, Vertex v1)
+{
+    for (auto h : mesh.halfedges(v1))
+    {
+        // halfedges() returns the outgoing half-edges around v.
+        // Each half-edge stores the vertex it points to, so to update
+        // the topolgy, we get the opposites of the outgoing half-edges
+        // and set these.
+
+        mesh.set_vertex(mesh.opposite_halfedge(h), v0);
+    }
+
+    // Before deleting the vertex, make sure the mesh doesn't think it
+    // points to anything that should be deleted with it.
+
+    mesh.set_halfedge(v1, Halfedge());
+
+    mesh.delete_vertex(v1);
+}
+
+// Finds all edges which share vertices and combines them, removing
+// the boundaries from the mesh.
+void Merge::merge_edges()
+{
+    std::unordered_map<uint64_t, std::vector<Halfedge>> edge_hash;
+
+    for (auto h : mesh.halfedges())
+    {
+        uint64_t to = mesh.to_vertex(h).idx();
+        uint64_t from = mesh.from_vertex(h).idx();
+
+        // Each matching pair will occur twice, once for each direction,
+        // so make sure to only capture it once.
+        if (to > from)
+        {
+            continue;
+        }
+
+        uint64_t key = (to << 32) | from;
+        edge_hash[key].push_back(h);
+    }
+
+    for (auto pair : edge_hash)
+    {
+        auto edges = pair.second;
+
+        if (edges.size() > 1)
+        {
+            // Where there is a boundary that can be combined, it should
+            // occur exactly once.
+            assert(edges.size() == 2);
+
+            // h1 must be the boundary edge in the pair
+            auto h1 = edges[0];
+            auto h2 = edges[1];
+            if (!mesh.is_boundary(h1) && mesh.is_boundary(h2))
+            {
+                std::swap(h1, h2);
+            }
+
+            mesh.combine_edges(h1, h2);
+        }
+    }
+}

--- a/src/pmp/algorithms/Merge.h
+++ b/src/pmp/algorithms/Merge.h
@@ -1,0 +1,33 @@
+// Copyright 2011-2023 the Polygon Mesh Processing Library developers.
+// Distributed under a MIT-style license, see LICENSE.txt for details.
+
+#pragma once
+
+#include "pmp/SurfaceMesh.h"
+#include "pmp/BoundingBox.h"
+
+namespace pmp {
+
+class Merge
+{
+public:
+    Merge(SurfaceMesh& mesh);
+
+    // Merges all vertices that are within the given distance and (normal) angle
+    // of eachother, and the edges incident to them as well, where possible.
+    void merge(float angle_degress = 30, float tolerance = 0);
+
+private:
+    void build_map();
+    void merge_vertices();
+    void merge_vertices(Vertex v0, Vertex v1);
+    void merge_edges();
+
+private:
+    SurfaceMesh& mesh;
+    std::unordered_map<uint64_t, std::vector<Vertex>> map;
+    pmp::BoundingBox bounds;
+    float distance_threshold;
+    float angle_threshold_radians;
+};
+} // namespace pmp

--- a/tests/Helpers.cpp
+++ b/tests/Helpers.cpp
@@ -192,4 +192,56 @@ SurfaceMesh texture_seams_mesh()
     return mesh;
 }
 
+SurfaceMesh triangle_cube() 
+{
+    SurfaceMesh mesh;
+
+    auto v0 = mesh.add_vertex(pmp::Point(-0.5, -0.5, -0.5));
+    auto v1 = mesh.add_vertex(pmp::Point(0.5, -0.5, -0.5));
+    auto v2 = mesh.add_vertex(pmp::Point(0.5, 0.5, -0.5));
+    auto v3 = mesh.add_vertex(pmp::Point(-0.5, 0.5, -0.5));
+    auto v4 = mesh.add_vertex(pmp::Point(-0.5, 0.5, 0.5));
+    auto v5 = mesh.add_vertex(pmp::Point(0.5, 0.5, 0.5));
+    auto v6 = mesh.add_vertex(pmp::Point(0.5, -0.5, 0.5));
+    auto v7 = mesh.add_vertex(pmp::Point(-0.5, -0.5, 0.5));
+
+    mesh.add_triangle(v0, v2, v1);
+    mesh.add_triangle(v0, v3, v2);
+    mesh.add_triangle(v2, v3, v4);
+    mesh.add_triangle(v2, v4, v5);
+    mesh.add_triangle(v1, v2, v5);
+    mesh.add_triangle(v1, v5, v6);
+    mesh.add_triangle(v0, v7, v4);
+    mesh.add_triangle(v0, v4, v3);
+    mesh.add_triangle(v5, v4, v7);
+    mesh.add_triangle(v5, v7, v6);
+    mesh.add_triangle(v0, v6, v7);
+    mesh.add_triangle(v0, v1, v6);
+
+    return mesh;
+}
+
+SurfaceMesh quad_cube()
+{
+    SurfaceMesh mesh;
+
+    auto v0 = mesh.add_vertex(pmp::Point(-0.5, -0.5, -0.5));
+    auto v1 = mesh.add_vertex(pmp::Point(0.5, -0.5, -0.5));
+    auto v2 = mesh.add_vertex(pmp::Point(0.5, 0.5, -0.5));
+    auto v3 = mesh.add_vertex(pmp::Point(-0.5, 0.5, -0.5));
+    auto v4 = mesh.add_vertex(pmp::Point(-0.5, 0.5, 0.5));
+    auto v5 = mesh.add_vertex(pmp::Point(0.5, 0.5, 0.5));
+    auto v6 = mesh.add_vertex(pmp::Point(0.5, -0.5, 0.5));
+    auto v7 = mesh.add_vertex(pmp::Point(-0.5, -0.5, 0.5));
+
+    mesh.add_quad(v0, v3, v2, v1);
+    mesh.add_quad(v1, v2, v5, v6);
+    mesh.add_quad(v7, v4, v3, v0);
+    mesh.add_quad(v6, v5, v4, v7);
+    mesh.add_quad(v1, v6, v7, v0);
+    mesh.add_quad(v3, v4, v5, v2);
+
+    return mesh;
+}
+
 } // namespace pmp

--- a/tests/Helpers.h
+++ b/tests/Helpers.h
@@ -27,4 +27,10 @@ SurfaceMesh open_cone();
 // a mesh with texcoords and texture seams
 SurfaceMesh texture_seams_mesh();
 
+// a unit cube expressed as a triangle mesh
+SurfaceMesh triangle_cube();
+
+// a unit cube expressed as a quad
+SurfaceMesh quad_cube();
+
 } // namespace pmp

--- a/tests/MergeTest.cpp
+++ b/tests/MergeTest.cpp
@@ -1,0 +1,327 @@
+// Copyright 2017-2021 the Polygon Mesh Processing Library developers.
+// Distributed under a MIT-style license, see LICENSE.txt for details.
+
+#include "gtest/gtest.h"
+
+#include "pmp/algorithms/Merge.h"
+#include "pmp/algorithms/Normals.h"
+#include "Helpers.h"
+
+using namespace pmp;
+
+// This function takes a well-formed mesh and splits it up by face to emulate
+// a mesh with per-vertex normals that would be typically be encountered where
+// there is no support for per-edge or per-face normals.
+void prepare_mesh(SurfaceMesh a, SurfaceMesh& b) 
+{
+    auto a_p = a.get_vertex_property<pmp::Point>("v:point");
+
+    for (auto f : a.faces())
+    {
+        std::vector<Vertex> b_vertices;
+        for (auto v : a.vertices(f))
+        {
+            b_vertices.push_back(b.add_vertex(a_p[v]));
+        }
+        b.add_face(b_vertices);
+    }
+
+    Normals::compute_vertex_normals(b);
+}
+
+void remove_faces(SurfaceMesh& mesh, std::vector<size_t> indices)
+{
+    auto v = *mesh.vertices_begin();
+    std::vector<pmp::Face> faces;
+    for (auto f : mesh.faces(v))
+    {
+        faces.push_back(f);
+    }
+    for (auto i : indices)
+    {
+        mesh.delete_face(faces[i]);
+    }
+}
+
+// This function checks that all primitives (vertices, halfedges, faces) only
+// point to valid indices, by collecting valid indices from the enumerators
+// and checking any references against these.
+void check_references(SurfaceMesh& mesh) 
+{
+    std::set<pmp::IndexType> vertex_indices;
+    for (auto v : mesh.vertices())
+    {
+        EXPECT_TRUE(v.is_valid());
+        vertex_indices.insert(v.idx());
+    }
+
+    size_t face_valence_sum = 0;
+
+    std::set<pmp::IndexType> face_indices;
+    for (auto f : mesh.faces())
+    {
+        EXPECT_TRUE(f.is_valid());
+        face_indices.insert(f.idx());
+        face_valence_sum += mesh.valence(f);
+    }
+
+    std::set<pmp::IndexType> edge_indices;
+    for (auto e : mesh.halfedges())
+    {
+        EXPECT_TRUE(e.is_valid());
+        edge_indices.insert(e.idx());
+    }
+
+    for (auto v : mesh.vertices())
+    {
+        EXPECT_GT(edge_indices.count(mesh.halfedge(v).idx()), 0);
+        for (auto h : mesh.halfedges(v))
+        {
+            EXPECT_TRUE(h.is_valid());
+            EXPECT_GT(edge_indices.count(h.idx()), 0);
+        }
+        for(auto f : mesh.faces(v))
+        {
+            if (f.is_valid())
+            {
+                EXPECT_GT(face_indices.count(f.idx()), 0);
+            }
+        }
+    }
+
+    size_t face_halfedge_references_sum = 0;
+    for (auto h : mesh.halfedges())
+    {
+        EXPECT_TRUE(mesh.from_vertex(h).is_valid());
+        EXPECT_TRUE(mesh.to_vertex(h).is_valid());
+        EXPECT_GT(vertex_indices.count(mesh.from_vertex(h).idx()), 0);
+        EXPECT_GT(vertex_indices.count(mesh.to_vertex(h).idx()), 0);
+        if (mesh.face(h).is_valid())
+        {
+            EXPECT_GT(face_indices.count(mesh.face(h).idx()), 0);
+            face_halfedge_references_sum++;
+        }
+        if (!mesh.is_boundary(h)) // Edges without a face may still have next and prev edges where there is a hole, but all faces must be closed.
+        {
+            EXPECT_TRUE(mesh.next_halfedge(h).is_valid());
+            EXPECT_TRUE(mesh.prev_halfedge(h).is_valid());
+            EXPECT_GT(edge_indices.count(mesh.next_halfedge(h).idx()), 0);
+            EXPECT_GT(edge_indices.count(mesh.prev_halfedge(h).idx()), 0);
+        }
+    }
+
+    for (auto f : mesh.faces())
+    {
+        for(auto h : mesh.halfedges(f))
+        {
+            EXPECT_TRUE(h.is_valid());
+            EXPECT_GT(edge_indices.count(h.idx()), 0);
+        }
+    }
+
+    EXPECT_EQ(face_valence_sum, face_halfedge_references_sum);
+}
+
+// This tests a number of preconditions to the actual tests, such that the
+// procedurally generated meshes are as expected.
+TEST(MergeTest, pretests) 
+{
+    auto c = triangle_cube();
+
+    EXPECT_EQ(c.n_vertices(), 8);
+    EXPECT_EQ(c.n_edges(), 18);
+    EXPECT_EQ(c.n_halfedges(), 36);
+    EXPECT_EQ(c.n_faces(), 12);
+
+    auto q = quad_cube();
+
+    EXPECT_EQ(q.n_vertices(), 8);
+    EXPECT_EQ(q.n_edges(), 12);
+    EXPECT_EQ(q.n_halfedges(), 24);
+    EXPECT_EQ(q.n_faces(), 6);
+}
+
+// This tests that the merge performs in the typical use case. It is expected
+// to reduce the vertex and edge count of the subdivided mesh.
+TEST(MergeTest, simple)
+{
+    // This snippet creates a mesh consisting of a soup of isolated triangles
+    SurfaceMesh mesh;
+    prepare_mesh(subdivided_icosahedron(), mesh);
+
+    check_references(mesh);
+
+    // This snippet and its counterpart check the number of edges for a face,
+    // only vertices and edges should be merged: collapsing edges or combining
+    // faces is different operation (decimation), so the faces should remain
+    // unchanged.
+
+    auto n_faces = mesh.n_faces();
+    std::unordered_map<int, int> valence;
+    for (auto f : mesh.faces())
+    {
+        valence[f.idx()] = mesh.valence(f);
+    }
+
+    size_t num_vertices_before = mesh.n_vertices();
+    size_t num_edges_before = mesh.n_halfedges();
+
+    Merge merge(mesh);
+    merge.merge();
+
+    check_references(mesh);
+
+    mesh.garbage_collection();
+
+    check_references(mesh);
+
+    EXPECT_EQ(mesh.n_faces(), n_faces);
+    for (auto f : mesh.faces())
+    {
+        EXPECT_EQ(mesh.valence(f), valence[f.idx()]);
+    }
+
+    // For this test, we expect the count to decrease because the per-vertex normals
+    // are within the default range.
+    EXPECT_LT(mesh.n_vertices(), num_vertices_before);
+    EXPECT_LT(mesh.n_halfedges(), num_edges_before);
+}
+
+
+// This tests the merge against a triangle mesh with sharp edges, only some of
+// which should be merged.
+TEST(MergeTest, tricube) 
+{
+    SurfaceMesh mesh;
+    prepare_mesh(triangle_cube(), mesh);
+
+    Merge merge(mesh);
+    merge.merge();
+
+    mesh.garbage_collection();
+
+    check_references(mesh);
+
+    // During the merge, two vertices of each side can be combined: the ones
+    // at the ends of the diagonal edges.
+    // This should result in each side (6 in total) having 4 vertices, and 5 
+    // edges.
+
+    EXPECT_EQ(mesh.n_vertices(), 24); // 4 vertices per each of six sides
+    EXPECT_EQ(mesh.n_edges(), 30); // 5 edges per each of six sides
+    EXPECT_EQ(mesh.n_halfedges(), 60); // Double the number of half edges
+    EXPECT_EQ(mesh.n_faces(), 12); // We don't remove the diagonal, simply combine the two co-located boundaries, so there are still 12 faces
+}
+
+// This tests the merge against a quad mesh with sharp edges. The nature of the
+// quad mesh means no edges are viable for merging, and so the mesh should 
+// remain unchanged.
+TEST(MergeTest, quadcube)
+{
+    SurfaceMesh mesh;
+    prepare_mesh(quad_cube(), mesh);
+
+    Merge merge(mesh);
+    merge.merge();
+
+    mesh.garbage_collection();
+
+    check_references(mesh);
+
+    // Merging a quad cube should result in a no-op, as none of the vertices
+    // can be combined, and all edges have unique start and end points.
+
+    EXPECT_EQ(mesh.n_vertices(), 24);  // 4 vertices per each of six sides
+    EXPECT_EQ(mesh.n_edges(), 24);     // 4 edges per each of six sides
+    EXPECT_EQ(mesh.n_halfedges(), 48); // Double the number of half edges
+    EXPECT_EQ(mesh.n_faces(), 6); // One quad per side
+}
+
+// This tests the merge against a sharp angled quad mesh again, but this time
+// with the angle threshold set very high. As a result, the mesh should become
+// the simplest possible unit cube.
+TEST(MergeTest, high_angle_threshold)
+{
+    SurfaceMesh mesh;
+    prepare_mesh(quad_cube(), mesh);
+
+    Merge merge(mesh);
+    merge.merge(180);
+
+    mesh.garbage_collection();
+
+    // Merging a quad cube should result in a no-op, as none of the vertices
+    // can be combined, and all edges have unique start and end points.
+
+    EXPECT_EQ(mesh.n_vertices(), 8);  // 4 vertices per each of six sides
+    EXPECT_EQ(mesh.n_edges(), 12);     // 4 edges per each of six sides
+    EXPECT_EQ(mesh.n_halfedges(), 24); // Double the number of half edges
+    EXPECT_EQ(mesh.n_faces(), 6);      // One quad per side
+}
+
+// This tests the merge against a mesh with one large hole
+TEST(MergeTest, open_face)
+{
+    auto c = triangle_cube();
+
+    // Pick two incident faces around a single vertex to create a hole with more
+    // than three edges.
+    remove_faces(c, {0, 1});
+
+    c.garbage_collection();
+
+    SurfaceMesh mesh;
+    prepare_mesh(c, mesh);
+
+    // After pre-processing the mesh it should have 12 faces, with each face
+    // having three vertices, and three edges.
+
+    Merge merge(mesh);
+    merge.merge();
+
+    mesh.garbage_collection();
+
+    check_references(mesh);
+
+    // In the case where the cube is missing one side, we expect 4 vertices and
+    // 5 edges for each complete side, and nothing else.
+
+    EXPECT_EQ(mesh.n_vertices(), 20);
+    EXPECT_EQ(mesh.n_edges(), 25);
+    EXPECT_EQ(mesh.n_halfedges(), 50);
+    EXPECT_EQ(mesh.n_faces(), 10);
+}
+
+// This tests the merge against a mesh with two holes, both incident to the 
+// same vertex.
+TEST(MergeTest, open_faces)
+{
+    auto c = triangle_cube();
+
+    // Pick two faces around a single vertex to remove to create multiple holes.
+    remove_faces(c, {0, 3});
+
+    c.garbage_collection();
+
+    SurfaceMesh mesh;
+    prepare_mesh(c, mesh);
+
+    // After pre-processing the mesh it should have 12 faces, with each face
+    // having three vertices, and three edges.
+
+    Merge merge(mesh);
+    merge.merge();
+
+    mesh.garbage_collection();
+
+    check_references(mesh);
+
+    // In the case where the cube is missing two faces and with the angle
+    // threshold low, we would expect 22 vertices: 16 for the 4 complete sides,
+    // and three for the 2 incomplete sides.
+
+    EXPECT_EQ(mesh.n_vertices(), 22);   
+    EXPECT_EQ(mesh.n_edges(), 26);     
+    EXPECT_EQ(mesh.n_halfedges(), 52); 
+    EXPECT_EQ(mesh.n_faces(), 10);      
+}


### PR DESCRIPTION
This PR adds a new algorithm, Merge, which closes boundaries in polygon-soup meshes.

The PR specifically:

1. Adds a new topological operation to SurfaceMesh, `combine_edges`, which connects two faces along boundary edges that share vertices.
2. Added an algorithm class to use hashing to find first co-located vertices, then edges, and to combine them using `SurfaceMesh` topological operations.
3. Added unit tests and an example for the new algorithm.