### PR TITLE
ISSUE #4 Added boundary quadric to Decimation

### DIFF
--- a/src/pmp/algorithms/Decimation.cpp
+++ b/src/pmp/algorithms/Decimation.cpp
@@ -113,6 +113,23 @@ void Decimation::initialize(Scalar aspect_ratio, Scalar edge_length,
             {
                 vquadric_[v] += Quadric(fnormal_[f], vpoint_[v]);
             }
+
+            for (auto h : mesh_.halfedges(v))
+            {
+                if (mesh_.is_boundary(mesh_.edge(h)))
+                {
+                    auto f = mesh_.face(h);
+                    if (f.is_valid())
+                    {
+                        auto d = normalize(vpoint_[mesh_.to_vertex(h)] -
+                                           vpoint_[mesh_.from_vertex(h)]);
+                        auto n = fnormal_[f];
+                        auto en = normalize(cross(d, n));
+
+                        vquadric_[v] += Quadric(en, vpoint_[v]);
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
This PR adds a new step to the `Decimation::initialise` method, which adds a quadric for the plane perpendicular to the face of any boundary edge.

The purpose is to improve Decimation quality by guiding the algorithm away from salient edges.