### PR TITLE
ISSUE #7 Added support for the v:normal property to read/write_pmp

### DIFF
--- a/src/pmp/io/read_pmp.cpp
+++ b/src/pmp/io/read_pmp.cpp
@@ -27,6 +27,9 @@ void read_pmp(SurfaceMesh& mesh, const std::filesystem::path& file)
     bool has_htex{false};
     tfread(in, has_htex);
 
+    bool has_vnormal{false};
+    tfread(in, has_vnormal);    
+
     // resize containers
     mesh.vprops_.resize(nv);
     mesh.hprops_.resize(nh);
@@ -52,6 +55,13 @@ void read_pmp(SurfaceMesh& mesh, const std::filesystem::path& file)
         auto htex = mesh.halfedge_property<TexCoord>("h:tex");
         size_t nhtc = fread((char*)htex.data(), sizeof(TexCoord), nh, in);
         PMP_ASSERT(nhtc == nh);
+    }
+
+    if (has_vnormal)
+    {
+        auto vnormal = mesh.vertex_property<Normal>("v:normal");
+        size_t nvn = fread((char*)vnormal.data(), sizeof(Normal), nv, in);
+        PMP_ASSERT(nvn == nv);
     }
 
     fclose(in);

--- a/src/pmp/io/write_pmp.cpp
+++ b/src/pmp/io/write_pmp.cpp
@@ -17,6 +17,7 @@ void write_pmp(const SurfaceMesh& mesh, const std::filesystem::path& file,
 
     // get properties
     auto htex = mesh.get_halfedge_property<TexCoord>("h:tex");
+    auto vnormal = mesh.get_vertex_property<Normal>("v:normal");
 
     // how many elements?
     auto nv = mesh.n_vertices();
@@ -29,6 +30,7 @@ void write_pmp(const SurfaceMesh& mesh, const std::filesystem::path& file,
     tfwrite(out, ne);
     tfwrite(out, nf);
     tfwrite(out, (bool)htex);
+    tfwrite(out, (bool)vnormal);
 
     // write properties to file
     // clang-format off
@@ -41,6 +43,9 @@ void write_pmp(const SurfaceMesh& mesh, const std::filesystem::path& file,
     // texture coordinates
     if (htex)
         fwrite((char*)htex.data(), sizeof(TexCoord), nh, out);
+
+    if (vnormal)
+        fwrite((char*)vnormal.data(), sizeof(Normal), nv, out);
 
     fclose(out);
 }

--- a/src/pmp/io/write_pmp.h
+++ b/src/pmp/io/write_pmp.h
@@ -10,7 +10,7 @@
 
 namespace pmp {
 
-void write_pmp(SurfaceMesh& mesh, const std::filesystem::path& file,
+void write_pmp(const SurfaceMesh& mesh, const std::filesystem::path& file,
                const IOFlags& flags);
 
 } // namespace pmp


### PR DESCRIPTION
This PR adds support for reading and writing the `v:normal` property in read/write_pmp.