### PR TITLE
ISSUE #15 Added filesystem::path shim

### DIFF
--- a/src/pmp/SurfaceMesh.h
+++ b/src/pmp/SurfaceMesh.h
@@ -5,11 +5,27 @@
 #pragma once
 
 #include <vector>
-#include <filesystem>
 
 #include "pmp/Types.h"
 #include "pmp/Properties.h"
 #include "pmp/io/IOFlags.h"
+
+namespace std {
+    namespace filesystem
+    {
+        class path
+        {
+            std::string inner;
+
+        public:
+            path(const char* s) { inner = std::string(s); }
+            path(std::string s) { inner = std::string(s); }
+
+            path extension() const { return path(inner.substr(inner.size() - 4)); }
+            std::string string() const { return inner; }
+        };
+    }
+}
 
 namespace pmp {
 

--- a/src/pmp/io/io.h
+++ b/src/pmp/io/io.h
@@ -3,8 +3,6 @@
 
 #pragma once
 
-#include <filesystem>
-
 #include "pmp/io/IOFlags.h"
 #include "pmp/SurfaceMesh.h"
 

--- a/src/pmp/io/read_obj.h
+++ b/src/pmp/io/read_obj.h
@@ -3,8 +3,6 @@
 
 #pragma once
 
-#include <filesystem>
-
 #include "pmp/SurfaceMesh.h"
 
 namespace pmp {

--- a/src/pmp/io/read_off.h
+++ b/src/pmp/io/read_off.h
@@ -2,9 +2,6 @@
 // Distributed under a MIT-style license, see LICENSE.txt for details.
 
 #pragma once
-
-#include <filesystem>
-
 #include "pmp/SurfaceMesh.h"
 
 namespace pmp {

--- a/src/pmp/io/read_pmp.h
+++ b/src/pmp/io/read_pmp.h
@@ -3,8 +3,6 @@
 
 #pragma once
 
-#include <filesystem>
-
 #include "pmp/SurfaceMesh.h"
 
 namespace pmp {

--- a/src/pmp/io/read_stl.h
+++ b/src/pmp/io/read_stl.h
@@ -3,8 +3,6 @@
 
 #pragma once
 
-#include <filesystem>
-
 #include "pmp/SurfaceMesh.h"
 
 namespace pmp {

--- a/src/pmp/io/write_obj.h
+++ b/src/pmp/io/write_obj.h
@@ -2,9 +2,6 @@
 // Distributed under a MIT-style license, see LICENSE.txt for details.
 
 #pragma once
-
-#include <filesystem>
-
 #include "pmp/io/IOFlags.h"
 #include "pmp/SurfaceMesh.h"
 

--- a/src/pmp/io/write_off.h
+++ b/src/pmp/io/write_off.h
@@ -2,9 +2,6 @@
 // Distributed under a MIT-style license, see LICENSE.txt for details.
 
 #pragma once
-
-#include <filesystem>
-
 #include "pmp/io/IOFlags.h"
 #include "pmp/SurfaceMesh.h"
 

--- a/src/pmp/io/write_pmp.h
+++ b/src/pmp/io/write_pmp.h
@@ -2,9 +2,6 @@
 // Distributed under a MIT-style license, see LICENSE.txt for details.
 
 #pragma once
-
-#include <filesystem>
-
 #include "pmp/io/IOFlags.h"
 #include "pmp/SurfaceMesh.h"
 

--- a/src/pmp/io/write_stl.h
+++ b/src/pmp/io/write_stl.h
@@ -2,9 +2,6 @@
 // Distributed under a MIT-style license, see LICENSE.txt for details.
 
 #pragma once
-
-#include <filesystem>
-
 #include "pmp/io/IOFlags.h"
 #include "pmp/SurfaceMesh.h"
 


### PR DESCRIPTION
This PR adds a filesystem shim to the top of SurfaceMesh, and removes the filesystem headers from the other .io files.

The shim allows the library to compile on gcc9.8. 

Removing the headers makes it easier to swap the shim out or guard it with conditionals in the future; all the files reference SurfaceMesh.h anyway, and SurfaceMesh.h contains a reference to filesystem::path, so will itself always include the header (or shim) regardless.