### PR TITLE
ISSUE #18 call adjust_outgoing_halfedge where new vertices are introd…

### DIFF
--- a/src/pmp/SurfaceMesh.cpp
+++ b/src/pmp/SurfaceMesh.cpp
@@ -1151,6 +1151,7 @@ void SurfaceMesh::combine_edges(Halfedge h1, Halfedge h2)
             set_vertex(h3p, nv);
             set_vertex(opposite_halfedge(h1n), nv);
             set_halfedge(nv, opposite_halfedge(h3p));
+            adjust_outgoing_halfedge(nv);
         }
     }
 
@@ -1173,6 +1174,7 @@ void SurfaceMesh::combine_edges(Halfedge h1, Halfedge h2)
             set_vertex(h1p, nv);
             set_vertex(opposite_halfedge(h3n), nv);
             set_halfedge(nv, opposite_halfedge(h1p));
+            adjust_outgoing_halfedge(nv);
         }
     }
 


### PR DESCRIPTION
This PR calls `adjust_outgoing_halfedge` when new vertices are introduced in `combine_edges`. This is necessary because the introduction of new vertices is necessary to prevent non-manifold vertices being created when the mesh is retopoligised; however after cloning the vertex, it may have a non-boundary edge set as its halfedge, and when used as a corner of the split face, should always have a boundary halfedge set, by convention. `adjust_outgoing_halfedge` makes sure this is true.