### PR TITLE
Issue 26

### DIFF
--- a/src/pmp/SurfaceMesh.cpp
+++ b/src/pmp/SurfaceMesh.cpp
@@ -805,6 +805,13 @@ bool SurfaceMesh::is_collapse_ok(Halfedge v0v1) const
                 return false;
     }
 
+    // vertices cannot be connected by multiple edges
+    for (auto vh : halfedges(v0))
+    {
+        if (vh != v0v1 && to_vertex(vh) == v1)
+            return false;
+    }
+
     // passed all tests
     return true;
 }

--- a/src/pmp/utilities.cpp
+++ b/src/pmp/utilities.cpp
@@ -48,6 +48,23 @@ void check_mesh(SurfaceMesh& mesh)
         }
     }
 
+    // Check edges do not point to or from their own opposites
+
+    for (auto h : mesh.halfedges())
+    {
+        if (mesh.next_halfedge(h) == mesh.opposite_halfedge(h))
+        {
+            auto what = "Found a halfedge that points to its own opposite.";
+            throw pmp::TopologyException(what);
+        }
+
+        if (mesh.prev_halfedge(h) == mesh.opposite_halfedge(h))
+        {
+            auto what = "Found a halfedge that points from its own opposite.";
+            throw pmp::TopologyException(what);
+        }
+    }
+
     // Check for phantom references
 
     std::unordered_map<IndexType, std::set<IndexType>> outgoing_edges;


### PR DESCRIPTION
This PR adds a check to `is_collapse_ok()` that checks if any other edges from v0 connect to v1, which is not supported by `collapse()`.